### PR TITLE
Turn off strict SSL checks by default

### DIFF
--- a/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_datastoreinfo.pl
+++ b/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_datastoreinfo.pl
@@ -8,6 +8,7 @@
 # You can find full information here: http://www.zenoss.com/oss
 #
 ################################################################################
+BEGIN { $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0; }
 
 use strict;
 use warnings;

--- a/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_guestinfo.pl
+++ b/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_guestinfo.pl
@@ -8,6 +8,7 @@
 # You can find full information here: http://www.zenoss.com/oss
 #
 ################################################################################
+BEGIN { $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0; }
 
 use strict;
 use warnings;

--- a/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_hostinfo.pl
+++ b/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_hostinfo.pl
@@ -8,6 +8,7 @@
 # You can find full information here: http://www.zenoss.com/oss
 #
 ################################################################################
+BEGIN { $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0; }
 
 use strict;
 use warnings;

--- a/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_interfaceinfo.pl
+++ b/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_interfaceinfo.pl
@@ -8,6 +8,7 @@
 # You can find full information here: http://www.zenoss.com/oss
 #
 ################################################################################
+BEGIN { $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0; }
 
 use strict;
 use warnings;

--- a/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_monitor.pl
+++ b/ZenPacks/community/VMwareESXiMonitor/libexec/esxi_monitor.pl
@@ -8,6 +8,7 @@
 # You can find full information here: http://www.zenoss.com/oss
 #
 ################################################################################
+BEGIN { $ENV{PERL_LWP_SSL_VERIFY_HOSTNAME} = 0; }
 
 use strict;
 use warnings;


### PR DESCRIPTION
Newer Perls / LWP libraries turn on strict SSL checks by default - turn them off again when running each script